### PR TITLE
remove the renv step from render-rmarkdown.yml

### DIFF
--- a/.github/workflows/render-rmarkdown.yml
+++ b/.github/workflows/render-rmarkdown.yml
@@ -24,8 +24,6 @@ jobs:
 
       - uses: r-lib/actions/setup-r@v2
 
-      - uses: r-lib/actions/setup-renv@v2
-
       - name: Render README.Rmd and Commit Results
         run: |
           RMD_PATH=($(git diff --name-only ${{ github.event.before }} ${{ github.sha }} | grep 'README[.]Rmd$'))


### PR DESCRIPTION
Removed the renv step as I don't know (and don't want to know) how to create a lockfile to support this Action.
See https://github.com/r-lib/actions/issues/902